### PR TITLE
Fix invalid byte sequence in UTF-8 with Ruby 1.9.3

### DIFF
--- a/lib/princely.rb
+++ b/lib/princely.rb
@@ -98,6 +98,7 @@ class Princely
     pdf.close_write
     result = pdf.gets(nil)
     pdf.close_read
+    result.force_encoding('BINARY') if RUBY_VERSION >= "1.9"
     return result
   end
 


### PR DESCRIPTION
Starting with Ruby 1.9, the encoding of string has to be explicitly specified.
