### PR TITLE
Remove load path tampering and meaningless Gem::Specification DSL usage.

### DIFF
--- a/lib/princely.rb
+++ b/lib/princely.rb
@@ -1,4 +1,4 @@
-# PrinceXML Ruby interface. 
+# PrinceXML Ruby interface.
 # http://www.princexml.com
 #
 # Library by Subimage Interactive - http://www.subimage.com
@@ -14,7 +14,6 @@
 #     :type => 'application/pdf'
 #   )
 #
-$:.unshift(File.dirname(__FILE__))
 require 'logger'
 require 'princely/rails' if defined?(Rails)
 
@@ -38,7 +37,7 @@ class Princely
   end
 
   def log_file
-    @log_file ||= defined?(Rails) ? 
+    @log_file ||= defined?(Rails) ?
             Rails.root.join("log/prince.log") :
             File.expand_path(File.dirname(__FILE__) + "/log/prince.log")
   end
@@ -54,7 +53,7 @@ class Princely
       `which prince`.chomp
     end
   end
-  
+
   # Sets stylesheets...
   # Can pass in multiple paths for css files.
   #
@@ -63,7 +62,7 @@ class Princely
       @style_sheets << " -s #{sheet} "
     end
   end
-  
+
   # Returns fully formed executable path with any command line switches
   # we've set based on our variables.
   #
@@ -73,7 +72,7 @@ class Princely
     @exe_path << @style_sheets
     return @exe_path
   end
-  
+
   # Makes a pdf from a passed in string.
   #
   # Returns PDF as a stream, so we can use send_data to shoot
@@ -81,15 +80,15 @@ class Princely
   #
   def pdf_from_string(string, output_file = '-')
     path = self.exe_path()
-    # Don't spew errors to the standard out...and set up to take IO 
+    # Don't spew errors to the standard out...and set up to take IO
     # as input and output
     path << ' --silent - -o -'
-    
+
     # Show the command used...
     logger.info "\n\nPRINCE XML PDF COMMAND"
     logger.info path
     logger.info ''
-    
+
     # Actually call the prince command, and pass the entire data stream back.
     pdf = IO.popen(path, "w+")
     pdf.puts(string)
@@ -102,15 +101,15 @@ class Princely
 
   def pdf_from_string_to_file(string, output_file)
     path = self.exe_path()
-    # Don't spew errors to the standard out...and set up to take IO 
+    # Don't spew errors to the standard out...and set up to take IO
     # as input and output
     path << " --silent - -o '#{output_file}' >> '#{log_file}' 2>> '#{log_file}'"
-    
+
     # Show the command used...
     logger.info "\n\nPRINCE XML PDF COMMAND"
     logger.info path
     logger.info ''
-    
+
     # Actually call the prince command, and pass the entire data stream back.
     pdf = IO.popen(path, "w+")
     pdf.puts(string)

--- a/princely.gemspec
+++ b/princely.gemspec
@@ -1,13 +1,9 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-
-require 'princely/version'
+require File.expand_path('../lib/princely/version', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = "princely"
   s.version = Princely::VERSION
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Michael Bleigh", "Jared Fraser"]
   s.date = "2013-01-16"
   s.description = "A wrapper for the PrinceXML PDF generation library."
@@ -29,14 +25,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.11"
   s.summary = "A simple Rails wrapper for the PrinceXML PDF generation library."
-
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-    else
-    end
-  else
-  end
 end
 


### PR DESCRIPTION
- Specifying rubygems >= 0 doesn't seem particularly helpful.
- Prevented princely from modifying the load path as Rubygems does this already.

Thanks!
