### PR TITLE
Add a global timeout feature

### DIFF
--- a/lib/princely.rb
+++ b/lib/princely.rb
@@ -86,7 +86,7 @@ class Princely
   #
   def exe_path
     # Add any standard cmd line arguments we need to pass
-    @exe_path << " --input=html --server --log=#{log_file} "
+    @exe_path << " --input=html --server --log='#{log_file}' "
     @exe_path << @cmd_args
     @exe_path << @style_sheets
     return @exe_path
@@ -117,7 +117,7 @@ class Princely
       result = pdf.gets(nil)
       pdf.close_read
       result.force_encoding('BINARY') if RUBY_VERSION >= "1.9"
-      return result      
+      return result
     end
   end
 
@@ -133,7 +133,7 @@ class Princely
     logger.info ''
 
     # Actually call the prince command, and pass the entire data stream back.
-    with_timeout do 
+    with_timeout do
       pdf = IO.popen(path, "w+")
       pdf.puts(string)
       pdf.close
@@ -166,7 +166,7 @@ class Princely
       child_pids << chunks[IDX_MAP[:pid]].to_i if chunks[IDX_MAP[:ppid]].to_i == parent_pid.to_i
     end
     grand_children = child_pids.map{|pid| get_children(pid)}.flatten
-    child_pids.concat grand_children 
+    child_pids.concat grand_children
   end
 
   def ps_axu
@@ -180,7 +180,7 @@ class Princely
       mem[pid] = chunks
       mem
     end
-  end  
+  end
 
   class StdoutLogger
     def self.info(msg)

--- a/lib/princely.rb
+++ b/lib/princely.rb
@@ -156,6 +156,8 @@ class Princely
         # just trap the error
       end
     end
+
+    raise TimeoutError.new("PrinceXML pdf generation exceeeded #{@timeout_seconds} seconds and was killed")
   end
 
   def get_children(parent_pid)
@@ -185,4 +187,6 @@ class Princely
       puts msg
     end
   end
+
+  class TimeoutError < StandardError; end
 end

--- a/spec/princely_spec.rb
+++ b/spec/princely_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Princely do
   let(:html_doc)  { "<html><body>Hello World</body></html>"}
-  
+
   # it "generates a PDF from HTML" do
   #   pdf = Princely.new.pdf_from_string html_doc
   #   pdf.should start_with("%PDF-1.4")
@@ -62,7 +62,7 @@ describe Princely do
       it "defaults in Rails" do
         # Fake Rails for this test.
         Rails = double(:root => Pathname.new('in_rails'), :logger => nil)
-        
+
         prince = Princely.new
         prince.log_file.to_s.should == 'in_rails/log/prince.log'
 
@@ -86,18 +86,18 @@ describe Princely do
       end
 
       it "appends default options" do
-        prince.exe_path.should == "/tmp/fake --input=html --server --log=/tmp/test_log "
+        prince.exe_path.should == "/tmp/fake --input=html --server --log='/tmp/test_log' "
       end
 
       it "adds stylesheet paths" do
         prince.style_sheets = " -s test.css "
-        prince.exe_path.should == "/tmp/fake --input=html --server --log=/tmp/test_log  -s test.css "
+        prince.exe_path.should == "/tmp/fake --input=html --server --log='/tmp/test_log'  -s test.css "
       end
 
       it "adds arbitrary command line args" do
-        prince.add_cmd_args "--fileroot=/some/root/path"
+        prince.add_cmd_args "--fileroot='/some/root/path'"
 
-        prince.exe_path.should == "/tmp/fake --input=html --server --log=/tmp/test_log  --fileroot=/some/root/path "
+        prince.exe_path.should == "/tmp/fake --input=html --server --log='/tmp/test_log'  --fileroot='/some/root/path' "
       end
     end
   end


### PR DESCRIPTION
These commits wrap the system call to princexml in a timeout block with some handy features.  If a timeout occurs this will attempt to kill the underlying princexml process running on the machine.  

This is in response to https://github.com/mbleigh/princely/issues/32

Of course, please let me know if there's something you'd have done differently and we can change it.  Also we are currently using this feature on our production stack with no issues.  

Thanks!
