### PR TITLE
Force the html_string become String, because it is possible like SafeBut...

### DIFF
--- a/lib/princely/asset_support.rb
+++ b/lib/princely/asset_support.rb
@@ -3,7 +3,7 @@ module Princely
     def localize_html_string(html_string, asset_path = nil)
       # Make all paths relative, on disk paths...
       html_string.gsub!(".com:/",".com/") # strip out bad attachment_fu URLs
-      html_string.gsub!( /src=["']+([^:]+?)["']/i ) do |m|
+      html_string.to_str.gsub!( /src=["']+([^:]+?)["']/i ) do |m|
         asset_src = asset_path ? "#{asset_path}/#{$1}" : asset_file_path($1)
         %Q{src="#{asset_src}"} # re-route absolute paths
       end


### PR DESCRIPTION
...ter that would cause $1 would not unavailable in the block.

The issue we meet is we try to generate the html_string in the presenter and the html_string is a SafeBuffer class,  then you could not get the $1 in the block.

reference: https://github.com/rails/rails/issues/1555
