### PR TITLE
Fix undefined method 'find_asset' for nil:NilClass error

### DIFF
--- a/lib/princely/asset_support.rb
+++ b/lib/princely/asset_support.rb
@@ -16,6 +16,7 @@ module Princely
 
     def asset_file_path(asset)
       # Remove /assets/ from generated names and try and find a matching asset
+      Rails.application.assets ||= Sprockets::Environment.new
       Rails.application.assets.find_asset(asset.gsub(%r{/assets/}, "")).try(:pathname) || asset
     end
   end


### PR DESCRIPTION
On upgrading `rails` version from `4.2.4` to `4.2.5`, the `render :pdf...` line in our code base started crashing with ` undefined method 'find_asset' for nil:NilClass` error message. The line that was crashing was `Rails.application.assets.find_asset(asset.gsub(%r{/assets/}, "")).try(:pathname) || asset` at https://github.com/mbleigh/princely/blob/27fc275a55195dd70515581e7665d3cd84b62522/lib/princely/asset_support.rb#L19

So `Rails.application.assets` is nil. 

Found a solution for fixing this issue at http://stackoverflow.com/a/30745005/429758

Adding `Rails.application.assets = Sprockets::Environment.new` before the above line fixes the issue on our code base.