### PR TITLE
Fix for rails5

### DIFF
--- a/lib/princely/pdf_helper.rb
+++ b/lib/princely/pdf_helper.rb
@@ -8,7 +8,7 @@ module Princely
       base.send :alias_method, :render, :render_with_princely
     end
 
-    def self.included(base)
+    def self.prepended(base)
       base.send :alias_method, :render_without_princely, :render
       base.send :alias_method, :render, :render_with_princely
     end

--- a/lib/princely/pdf_helper.rb
+++ b/lib/princely/pdf_helper.rb
@@ -8,6 +8,11 @@ module Princely
       base.send :alias_method, :render, :render_with_princely
     end
 
+    def self.included(base)
+      base.send :alias_method, :render_without_princely, :render
+      base.send :alias_method, :render, :render_with_princely
+    end
+
     def render_with_princely(options = nil, *args, &block)
       if options.is_a?(Hash) && options.has_key?(:pdf)
         options[:name] ||= options.delete(:pdf)

--- a/lib/princely/rails.rb
+++ b/lib/princely/rails.rb
@@ -7,6 +7,7 @@ end
 if defined?(Rails)
   if Rails::VERSION::MAJOR >= 5
     ActionController::Base.send(:prepend, Princely::PdfHelper)
+    ActionController::Base.send(:include, Princely::AssetSupport)
   else
     ActionController::Base.send(:include, Princely::PdfHelper)
   end


### PR DESCRIPTION
The "remove-alias-chain" commit is missing a couple of things that cause the gem to fail completely for Rails 5. This adds the missing code to correctly prepend "pdf_helper" and "asset_support".