### PR TITLE
Fix: AssetSupport not getting called in rails 5.2

### DIFF
--- a/lib/princely/pdf_helper.rb
+++ b/lib/princely/pdf_helper.rb
@@ -8,11 +8,6 @@ module Princely
       base.send :alias_method, :render, :render_with_princely
     end
 
-    def self.prepended(base)
-      base.send :alias_method, :render_without_princely, :render
-      base.send :alias_method, :render, :render_with_princely
-    end
-
     def render_with_princely(options = nil, *args, &block)
       if options.is_a?(Hash) && options.has_key?(:pdf)
         options[:name] ||= options.delete(:pdf)

--- a/lib/princely/rails.rb
+++ b/lib/princely/rails.rb
@@ -5,12 +5,6 @@ if Mime::Type.lookup_by_extension(:pdf) != 'application/pdf'
 end
 
 if defined?(Rails)
-  if Rails::VERSION::MAJOR >= 5
-    ActionController::Base.send(:prepend, Princely::PdfHelper)
-  else
-    ActionController::Base.send(:include, Princely::PdfHelper)
-  end
-  ActionController::Base.send(:include, Princely::AssetSupport) if
-   (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0) ||
-   (Rails::VERSION::MAJOR >= 4)
+  ActiveSupport.on_load(:action_controller) { include Princely::PdfHelper }
+  ActiveSupport.on_load(:action_controller) { include Princely::AssetSupport }
 end


### PR DESCRIPTION
In this PR:

- Switch to `ActiveSupport.on_load` rather than using `send`, this was introduced in Rails 3 so should be widely compatible.
- Removes the Rails version logic specific to the now 9 year old rails 3.0 version
- Reverts back to using `include` for the `Princely::PdfHelper` module, I'm not sure why it was switched to `prepend` but this prevents `Princely::AssetSupport` from being called and breaks asset paths as the compiled asset paths are used over the ones returned by `Princely::AssetSupport`. This issue is present in Rails 5.2, I've not tested on older versions.

I'm happy to split this PR into multiple commits if that would be preferred.