### PR TITLE
add custom executable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The defaults for the render options are as follows:
     server_flag:     true
     javascript_flag: false
     timeout:         none
+    exe_options:     none
 
 ## Contributors
 

--- a/lib/princely/pdf.rb
+++ b/lib/princely/pdf.rb
@@ -14,7 +14,8 @@ module Princely
         :logger => nil,
         :server_flag => true,
         :media => nil,
-        :javascript_flag => false
+        :javascript_flag => false,
+        :exe_options => []
       }.merge(options)
       @executable = options[:path] ? Princely::Executable.new(options[:path]) : options[:executable]
       @style_sheets = ''
@@ -24,6 +25,7 @@ module Princely
       @media = options[:media]
       @javascript_flag = options[:javascript_flag]
       @timeout = options[:timeout]
+      @custom_exe_options = options[:exe_options]
     end
 
     # Returns the instance logger or Princely default logger
@@ -58,6 +60,7 @@ module Princely
       options << "--media=#{media}" if media
       options << "--javascript" if @javascript_flag
       options << @style_sheets
+      options += @custom_exe_options
       options
     end
 

--- a/spec/princely/pdf_spec.rb
+++ b/spec/princely/pdf_spec.rb
@@ -51,6 +51,17 @@ describe Princely::Pdf do
     end
   end
 
+  describe "exe_options with array" do
+    before(:each) do
+      allow(prince).to receive(:log_file).and_return('/tmp/test_log')
+    end
+
+    let(:prince) { Princely::Pdf.new(:exe_options => ['--xml-external-entities']) }
+    it 'adds them to the other options' do
+      expect(prince.executable_options).to include('--xml-external-entities')
+    end
+  end
+
   describe "exe_path" do
     let(:prince) { Princely::Pdf.new(:path => '/tmp/fake') }
 


### PR DESCRIPTION
re: #63, this allows a user to pass in custom executable options. I need it to pass in `--xml-external-entities`, which was added in Prince 11.