### PR TITLE
Silence Prince message `fin|success`

### DIFF
--- a/lib/princely/pdf.rb
+++ b/lib/princely/pdf.rb
@@ -106,8 +106,11 @@ module Princely
 
       log_command path if options[:log_command]
 
+      # Make sure the log file exists before the pipe creation.
+      FileUtils.touch log_file
+
       # Actually call the prince command, and pass the entire data stream back.
-      pdf = IO.popen(path, "w+")
+      pdf = IO.popen(path, "w+", err: log_file.to_s)
       pdf.puts string
       pdf
     end

--- a/spec/princely/pdf_spec.rb
+++ b/spec/princely/pdf_spec.rb
@@ -8,7 +8,7 @@ describe Princely::Pdf do
   end
 
   it "generates a PDF from HTML" do
-    pdf = Princely::Pdf.new.pdf_from_string html_doc
+    pdf = Princely::Pdf.new(log_file: "/tmp/test_log").pdf_from_string html_doc
     expect(pdf).to start_with("%PDF-1.4")
     expect(pdf.rstrip).to end_with("%%EOF")
     pdf.length > 100


### PR DESCRIPTION
Prince outputs `fin|success` to `err`. This change sends the `err` to the `log_file`.

Fixes #64 