### PR TITLE
Rails 4 - use config.stylesheet_dir instead of Sprockets

### DIFF
--- a/lib/princely/asset_support.rb
+++ b/lib/princely/asset_support.rb
@@ -15,12 +15,12 @@ module Princely
     end
 
     def asset_file_path(asset)
-      if Rails.application.config.assets.compile
+      if Rails.application.assets.nil?
+        File.join(config.stylesheets_dir, "#{asset}.css")
+      else
         # Remove /assets/ from generated names and try and find a matching asset
         Rails.application.assets ||= Sprockets::Environment.new
         Rails.application.assets.find_asset(asset.gsub(%r{/assets/}, "")).try(:pathname) || asset
-      else
-        File.join(config.stylesheets_dir, "#{asset}.css")
       end
     end
   end

--- a/lib/princely/asset_support.rb
+++ b/lib/princely/asset_support.rb
@@ -15,12 +15,12 @@ module Princely
     end
 
     def asset_file_path(asset)
-      if Rails.application.assets.nil?
-        File.join(config.stylesheets_dir, "#{asset}.css")
-      else
+      if Rails.env.development?
         # Remove /assets/ from generated names and try and find a matching asset
         Rails.application.assets ||= Sprockets::Environment.new
         Rails.application.assets.find_asset(asset.gsub(%r{/assets/}, "")).try(:pathname) || asset
+      else
+        File.join(config.stylesheets_dir, "#{asset}.css")
       end
     end
   end

--- a/lib/princely/asset_support.rb
+++ b/lib/princely/asset_support.rb
@@ -15,9 +15,13 @@ module Princely
     end
 
     def asset_file_path(asset)
-      # Remove /assets/ from generated names and try and find a matching asset
-      Rails.application.assets ||= Sprockets::Environment.new
-      Rails.application.assets.find_asset(asset.gsub(%r{/assets/}, "")).try(:pathname) || asset
+      if Rails.application.config.assets.compile
+        # Remove /assets/ from generated names and try and find a matching asset
+        Rails.application.assets ||= Sprockets::Environment.new
+        Rails.application.assets.find_asset(asset.gsub(%r{/assets/}, "")).try(:pathname) || asset
+      else
+        File.join(config.stylesheets_dir, "#{asset}.css")
+      end
     end
   end
 end

--- a/lib/princely/rails.rb
+++ b/lib/princely/rails.rb
@@ -5,7 +5,7 @@ if Mime::Type.lookup_by_extension(:pdf) != 'application/pdf'
 end
 
 if defined?(Rails)
-  if Rails::VERSION::MAJOR >= 4
+  if Rails::VERSION::MAJOR >= 5
     ActionController::Base.send(:prepend, Princely::PdfHelper)
   else
     ActionController::Base.send(:include, Princely::PdfHelper)

--- a/lib/princely/rails.rb
+++ b/lib/princely/rails.rb
@@ -5,7 +5,7 @@ if Mime::Type.lookup_by_extension(:pdf) != 'application/pdf'
 end
 
 if defined?(Rails)
-  if Rails::VERSION::MAJOR >= 5
+  if Rails::VERSION::MAJOR >= 4
     ActionController::Base.send(:prepend, Princely::PdfHelper)
   else
     ActionController::Base.send(:include, Princely::PdfHelper)


### PR DESCRIPTION
Beginning with `sprockets-rails 3.0`, `Rails.application.assets` no longer works when `compile = false` (i.e. in Production mode). Instead, assets need to be located using `Rails.application.assets_manifest`. This breaks the current code in `assets_helper.rb` - it works in `development` mode, but not in `production` mode.

Since PrinceXML processing is all server-side, there isn't any advantage to using the Asset Pipeline. It's easier and more efficient to use `stylesheets_dir` for Rails 4 and up - like the gem currently does for Rails 5 and up.